### PR TITLE
Fixes possible buildout issue

### DIFF
--- a/brodul/recipe/template/__init__.py
+++ b/brodul/recipe/template/__init__.py
@@ -195,8 +195,7 @@ class Recipe(object):
             env.filters.update(filters)
         return env
 
-    @staticmethod
-    def _load_template(env, path):
+    def _load_template(self, env, path):
         """
         Tried to load the Jinja2 template given by the environment and
         template path.
@@ -208,8 +207,7 @@ class Recipe(object):
             log.error("Could not find the template file: %s" % e.name)
             raise zc.buildout.UserError("Template file not found: %s" % e.name)
 
-    @staticmethod
-    def _ensure_dir(directory):
+    def _ensure_dir(self, directory):
         """
         Ensures that the specified directory exists.
         """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="brodul.recipe.template",
-    version="1.2.1.jweede",
+    version="1.2.2",
     author="Andraz Brodnik",
     author_email="brodul@brodul.org",
     url="http://github.com/brodul/amplecode.recipe.template",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="brodul.recipe.template",
-    version="1.2.1",
+    version="1.2.1.jweede",
     author="Andraz Brodnik",
     author_email="brodul@brodul.org",
     url="http://github.com/brodul/amplecode.recipe.template",


### PR DESCRIPTION
For some reason calling the attrs on buildout directly in recipes can cause issues with larger custom buildouts. 
Buildout source advises against calling buildout attributes inside recipes. 
Here's a wrapper passed to jinja that redirects attribute calls to getitems instead.
